### PR TITLE
feat(lib): Remove prompting and update logging

### DIFF
--- a/generator-spring/generators/app/index.js
+++ b/generator-spring/generators/app/index.js
@@ -22,6 +22,7 @@ const Defaults = require('../../lib/defaults');
 const OpenApi = require('../../lib/openapi');
 
 const defaults = new Defaults();
+const logId = require('../../package.json').name;
 
 module.exports = class extends Generator {
 
@@ -30,19 +31,17 @@ module.exports = class extends Generator {
     if(!opts.context) throw "This generator cannot be run standalone, only composed with.";
     defaults.setOptions(this);
     extend(this, opts.context);   //inject the objects and functions directly into 'this' to make things easy
-    this.logger.writeToLog("Spring Generator context", opts.context);
-    const ext = this.promptmgr.add(require('../prompts/spring.js'));
-    ext.setContext(opts.context);
+    this.logger.writeToLog(`${logId}:constructor - context`, opts.context);
     this.conf.addMissing(opts, defaults);
     this.openApiDir = [];
-    this.logger.writeToLog("Spring Generator conf (final)", this.conf);
+    this.logger.writeToLog(`${logId}:constructor -  conf (final)`, this.conf);
   }
 
   initializing() {
   }
   
   prompting() {
-    //do not add questions in here, use the promptmgr on the context if you need to get input from the user
+    //this generator does not prompt, questions can be set in the prompts directory for testing purposes
   }
 
   configuring() {

--- a/generator-spring/generators/prompts/spring.js
+++ b/generator-spring/generators/prompts/spring.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+// Set prompts for use by ibm-java-utils generator
+
 'use strict'
 
 const PROMPT_ID = 'prompt:spring'

--- a/generator-spring/lib/openapi.js
+++ b/generator-spring/lib/openapi.js
@@ -135,7 +135,7 @@ const getServerSDKAsync = function (sdkName, generatedID) {
   // we are going to use .pipe() to stream the data to disk
   return new Promise((resolve, reject) => {
     const {sep} = require('path')
-    const tempDir = fs.mkdtempSync(os.tmpDir() + sep)
+    const tempDir = fs.mkdtempSync(os.tmpdir() + sep)
     logger.writeToLog(`starting server SDK download and unzip for ${sdkName} from ${serverDownloadURL} to ${tempDir}`)
     request.get({
       headers: {'Accept': 'application/zip'},

--- a/generator-spring/package.json
+++ b/generator-spring/package.json
@@ -13,7 +13,7 @@
     "handlebars": "^4.0.0",
     "yeoman-generator": "^1.0.0",
     "extend": "^3.0.1",
-    "ibm-java-codegen-common": "2.3.0",
+    "ibm-java-codegen-common": "3.0.0",
     "bluebird": "^3.5.0",
     "request": "^2.81.0",
     "unzip2": "^0.2.5"

--- a/generator-spring/test/integration/generator.openapi.test.js
+++ b/generator-spring/test/integration/generator.openapi.test.js
@@ -36,11 +36,8 @@ class Options extends AssertOpenApi {
   constructor (buildType, createType, bluemix) {
     super()
     this.conf = {
-      headless: 'true',
-      debug: 'true',
       buildType: buildType,
       createType: createType,
-      promptType: 'prompt:spring',
       appName: APPNAME,
       groupId: GROUPID,
       artifactId: ARTIFACTID,
@@ -56,7 +53,6 @@ class Options extends AssertOpenApi {
     this.before = function () {
       return helpers.run(path.join(__dirname, '../../generators/app'))
         .withOptions(this.options)
-        .withPrompts({})
         .toPromise()
     }
   }

--- a/generator-spring/test/integration/generator.spring.test.js
+++ b/generator-spring/test/integration/generator.spring.test.js
@@ -36,11 +36,8 @@ class Options extends AssertSpring {
   constructor (buildType, createType, envEntries) {
     super()
     this.conf = {
-      headless: 'true',
-      debug: 'true',
       buildType: buildType,
       createType: createType,
-      promptType: 'prompt:spring',
       envEntries: envEntries,
       appName: APPNAME,
       groupId: GROUPID,
@@ -54,7 +51,6 @@ class Options extends AssertSpring {
     this.before = function () {
       return helpers.run(path.join(__dirname, '../../generators/app'))
         .withOptions(this.options)
-        .withPrompts({})
         .toPromise()
     }
     this.assertHealthFiles = function (buildType) {


### PR DESCRIPTION
Remove promptingmgr from context module.
Remove headless as an option.
Remove debug as an option.
Change logging to use console.log or passed-in logger.

BREAKING CHANGE: Remove prompting, remove options, alter logging api

Signed-off-by: Katherine Stanley <katheris@uk.ibm.com>